### PR TITLE
Add compact specs with standardized format

### DIFF
--- a/.ai/specs/SPEC_FORMAT.md
+++ b/.ai/specs/SPEC_FORMAT.md
@@ -1,0 +1,81 @@
+# Spec Format Standard
+
+## Rules
+
+1. **Max 50 lines** - If longer, split into multiple specs
+2. **Structured frontmatter** - Required fields, machine-parseable
+3. **Link don't duplicate** - Reference code locations, don't copy code
+4. **One concern per file** - Not mega-specs
+5. **Validate regularly** - Update `validated` field when checking against code
+
+## Filename Pattern
+
+```
+<type>-<short-name>.md
+
+Examples:
+  bug-session-hijacking.md
+  feature-token-tracking.md
+  security-sandbox-isolation.md
+```
+
+## Template
+
+```markdown
+---
+id: <TYPE>-<NNN>        # SEC-001, BUG-002, FEAT-003
+type: bug | feature | security | refactor
+status: open | in_progress | done | wontfix
+severity: critical | high | medium | low  # for bugs/security
+location: <file:lines>  # primary code location
+issue: <number> | null  # linked GitHub issue
+validated: <YYYY-MM-DD> | null
+---
+
+# <Title>
+
+## Problem / Goal
+- Bullet points only
+- Max 5 points
+
+## Solution
+- Bullet points only
+- Reference code: `file.py:123`
+
+## Test
+- How to verify this works
+- One line per test case
+
+## Notes
+- Optional section
+- Edge cases, gotchas, links
+```
+
+## Frontmatter Fields
+
+| Field | Required | Values |
+|-------|----------|--------|
+| id | Yes | TYPE-NNN (e.g., SEC-001) |
+| type | Yes | bug, feature, security, refactor |
+| status | Yes | open, in_progress, done, wontfix |
+| severity | If bug/security | critical, high, medium, low |
+| location | Yes | file:lines or "multiple" |
+| issue | No | GitHub issue number or null |
+| validated | No | Date last checked against code |
+
+## Validation
+
+Specs can be validated with:
+
+```bash
+# Check all specs have required frontmatter
+grep -L "^id:" .ai/specs/*.md
+
+# Find specs not validated in 30 days
+# (tooling TBD)
+```
+
+## Examples
+
+Good: `security-session-hijacking.md` (40 lines, focused)
+Bad: `security.md` (200 lines, covers everything)

--- a/.ai/specs/bug-message-race.md
+++ b/.ai/specs/bug-message-race.md
@@ -1,0 +1,25 @@
+---
+id: BUG-002
+type: bug
+status: open
+severity: high
+location: src/koro/core/brain.py:71-171
+issue: null
+validated: 2026-01-28
+---
+
+# Race Condition in Concurrent Messages
+
+## Problem
+- No locking on `process_message()` per session
+- Two messages to same session: both read stale history
+- Last write wins, first message lost
+
+## Solution
+- Per-session `asyncio.Lock()` in Brain
+- `WeakValueDictionary` for auto-cleanup
+- Lock acquired before processing, released after
+
+## Test
+- Send "Hello" and "How are you?" simultaneously to same session
+- Expected: Both messages in history, none lost

--- a/.ai/specs/bug-session-switch-race.md
+++ b/.ai/specs/bug-session-switch-race.md
@@ -1,0 +1,25 @@
+---
+id: BUG-001
+type: bug
+status: open
+severity: high
+location: src/koro/core/brain.py:253-255
+issue: null
+validated: 2026-01-28
+---
+
+# Race Condition in Session Switching
+
+## Problem
+- No locking on `switch_session()`
+- Concurrent switch requests corrupt state
+- Grep confirms: no `Lock()` or mutex in codebase
+
+## Solution
+- Option A: Optimistic concurrency (version column)
+- Option B: Database-level `SELECT FOR UPDATE`
+- MVP: Add `version` column, reject stale updates
+
+## Test
+- Concurrent `switch_session(A)` and `switch_session(B)`
+- Expected: One succeeds, state is consistent (A or B, not corrupted)

--- a/.ai/specs/feature-docker-deps.md
+++ b/.ai/specs/feature-docker-deps.md
@@ -1,0 +1,34 @@
+---
+id: FEAT-003
+type: feature
+status: open
+severity: low
+location: Dockerfile:11-16
+issue: null
+validated: 2026-01-28
+---
+
+# Docker Dependencies
+
+## Goal
+- Include tools Claude needs for common operations
+- Currently missing: git, gh, jq, ripgrep
+
+## Solution
+Add to Dockerfile:
+```dockerfile
+RUN apt-get update && apt-get install -y \
+    git jq ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=...] ..." \
+    | tee /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh
+```
+
+## Test
+- `docker exec koro git --version` → works
+- `docker exec koro gh --version` → works

--- a/.ai/specs/feature-skills-management.md
+++ b/.ai/specs/feature-skills-management.md
@@ -1,0 +1,33 @@
+---
+id: FEAT-002
+type: feature
+status: open
+severity: medium
+location: src/koro/core/tools/registry.py
+issue: null
+validated: 2026-01-28
+---
+
+# Skills Management via Settings
+
+## Goal
+- Users enable/disable Claude Code skills
+- Telegram `/skills` command and settings menu
+- Persist preferences in user settings
+
+## Solution
+- Scan `~/.claude/skills/*/SKILL.md` for available skills
+- Add `disabled_skills` to UserSettings
+- Filter skills before passing to Claude SDK
+
+## UI
+```
+/skills              - List with status
+/skills disable X    - Disable skill X
+/skills enable X     - Enable skill X
+```
+
+## Test
+- Disable "commit" skill
+- Ask Claude to run /commit
+- Expected: Skill not available

--- a/.ai/specs/feature-token-tracking.md
+++ b/.ai/specs/feature-token-tracking.md
@@ -1,0 +1,38 @@
+---
+id: FEAT-001
+type: feature
+status: open
+severity: high
+location: src/koro/core/brain.py:143-151
+issue: null
+validated: 2026-01-28
+---
+
+# Token Usage Tracking
+
+## Goal
+- Track Claude token consumption per request
+- Track ElevenLabs TTS characters
+- Enable billing, quotas, analytics
+
+## Solution
+- New `usage` table: user_id, session_id, input_tokens, output_tokens, tts_chars
+- Extract tokens from Claude SDK response metadata
+- Record after each `process_message()` call
+
+## Data
+```sql
+CREATE TABLE usage (
+    id INTEGER PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    session_id TEXT,
+    timestamp TEXT DEFAULT (datetime('now')),
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    tts_characters INTEGER
+);
+```
+
+## Test
+- Send message, query usage table
+- Expected: Row with token counts > 0

--- a/.ai/specs/security-sandbox-isolation.md
+++ b/.ai/specs/security-sandbox-isolation.md
@@ -1,0 +1,26 @@
+---
+id: SEC-002
+type: security
+status: open
+severity: critical
+location: src/koro/core/config.py:59-61
+issue: null
+validated: 2026-01-28
+---
+
+# Per-User Sandbox Isolation
+
+## Problem
+- `SANDBOX_DIR` is global, shared by all users
+- User A's Claude can read/modify User B's files
+- Dockerfile:65 sets single `/home/claude/sandbox`
+
+## Solution
+- Dynamic per-user paths: `~/.koromind/sandboxes/{user_id}/`
+- Pass user-specific sandbox to `ClaudeAgentOptions`
+- Auto-create on first request, permissions 0700
+
+## Test
+- User A creates `secret.txt` in sandbox
+- User B asks Claude to read User A's file
+- Expected: Access denied

--- a/.ai/specs/security-session-hijacking.md
+++ b/.ai/specs/security-session-hijacking.md
@@ -1,0 +1,26 @@
+---
+id: SEC-001
+type: security
+status: open
+severity: critical
+location: src/koro/api/routes/messages.py:52-103
+issue: null
+validated: 2026-01-28
+---
+
+# Session Hijacking in Messages API
+
+## Problem
+- `/messages` accepts any `session_id` without ownership validation
+- Attacker can guess session IDs and access other users' conversations
+- `sessions.py:124-132` validates ownership, but `messages.py` does not
+
+## Solution
+- Add ownership check before `brain.process_message()`
+- Pattern: `if session_id not in user's sessions → 403`
+- Reference implementation: `sessions.py:124-132`
+
+## Test
+- User A creates session S1
+- User B calls `POST /messages` with `session_id=S1`
+- Expected: 403 Forbidden


### PR DESCRIPTION
## Summary
- Adds spec format standard (`.ai/specs/SPEC_FORMAT.md`)
- Adds 7 compact specs following the new format
- Each spec max 50 lines, structured frontmatter, machine-parseable

## Specs Added
| ID | File | Issue |
|----|------|-------|
| SEC-001 | `security-session-hijacking.md` | #17 |
| SEC-002 | `security-sandbox-isolation.md` | #18 |
| BUG-001 | `bug-session-switch-race.md` | #20 |
| BUG-002 | `bug-message-race.md` | #21 |
| FEAT-001 | `feature-token-tracking.md` | #15 |
| FEAT-002 | `feature-skills-management.md` | #16 |
| FEAT-003 | `feature-docker-deps.md` | #19 |

## Spec Format
```markdown
---
id: SEC-001
type: security
status: open
severity: critical
location: src/file.py:lines
issue: <number>
validated: YYYY-MM-DD
---

# Title

## Problem
## Solution
## Test
```

## Test plan
- [ ] Verify all specs have valid frontmatter
- [ ] Verify specs are under 50 lines each