### PR TITLE
chore: bump Python version to 3.12

### DIFF
--- a/.ai/specs/infra-docker.md
+++ b/.ai/specs/infra-docker.md
@@ -20,7 +20,7 @@ validated: 2026-01-29
 - Easy hosting on any Docker-capable server
 
 ## How
-- `Dockerfile` - Python 3.11 image, uv for deps
+- `Dockerfile` - Python 3.12 image, uv for deps
 - `docker-compose.yml` - Service definition
 
 ### Volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 26.1.0
     hooks:
       - id: black
-        language_version: python3.11
+        language_version: python3.12
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ KoroMind is a multi-interface personal AI assistant ("second brain") that connec
 ### Setup
 ```bash
 pip install uv
-uv venv -p python3.11
+uv venv -p python3.12
 source .venv/bin/activate
 uv sync --extra dev
 cp .env.example .env  # Then fill in credentials
@@ -128,7 +128,7 @@ Message → Brain.process_message() → STT (if voice) → Claude SDK → [Tools
 Legacy JSON files (`sessions_state.json`, `user_settings.json`) are auto-migrated on first run.
 
 ## Code Style
-- Python 3.11+, PEP 8
+- Python 3.12+, PEP 8
 - Type hints for function signatures
 - Black for formatting (line-length 88)
 - isort with black profile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ pip install uv
 
 2. Create a virtual environment:
 ```bash
-uv venv -p python3.11
+uv venv -p python3.12
 source .venv/bin/activate  # Linux/macOS
 # or: .venv\Scripts\activate  # Windows
 ```
@@ -66,7 +66,7 @@ pytest test_bot.py::test_transcribe_voice -v
 
 ## Code Style
 
-- Use Python 3.11+ features where appropriate
+- Use Python 3.12+ features where appropriate
 - Follow PEP 8 guidelines
 - Add type hints for function signatures
 - Keep functions focused and under 50 lines where possible

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,22 @@
 # Multi-stage build for efficient image size
 
 # ============================================================================
-# Stage 1: Base with Node.js and Python
+# Stage 1: Base with Node.js and Python 3.12
 # ============================================================================
 FROM node:20-slim AS base
 
-# Install Python and system dependencies
-# Note: Debian bookworm has Python 3.11, which is compatible
+# Install Python 3.12 and system dependencies
+# Note: We need Python 3.12+ for Pydantic + TypedDict compatibility
 RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-venv \
-    python3-pip \
+    software-properties-common \
     curl \
-    && rm -rf /var/lib/apt/lists/*
+    && echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list \
+    && apt-get update && apt-get install -y -t trixie \
+    python3.12 \
+    python3.12-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /etc/apt/sources.list.d/trixie.list \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python3
 
 # Create non-root user (uid 1000 required by Claude CLI)
 # Delete existing node user first (it has UID 1000)
@@ -38,7 +42,7 @@ WORKDIR /home/claude/app
 COPY --chown=claude:claude pyproject.toml uv.lock ./
 
 # Create virtual environment and install dependencies via uv
-RUN python3 -m venv .venv && \
+RUN python3.12 -m venv .venv && \
     .venv/bin/pip install --no-cache-dir --upgrade pip uv && \
     .venv/bin/uv sync --frozen --no-dev
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python 3.11+">
+  <img src="https://img.shields.io/badge/python-3.12+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+">
   <img src="https://img.shields.io/badge/Claude-Agent%20SDK-7c3aed?style=flat-square" alt="Claude Agent SDK">
   <img src="https://img.shields.io/badge/FastAPI-REST-009688?style=flat-square&logo=fastapi&logoColor=white" alt="FastAPI">
   <img src="https://img.shields.io/badge/Telegram-Bot-26a5e4?style=flat-square&logo=telegram&logoColor=white" alt="Telegram Bot">
@@ -100,7 +100,7 @@ src/koro/
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.12+
 - [Claude Code](https://claude.ai/code) installed
 - Telegram bot token from [@BotFather](https://t.me/botfather) (for Telegram interface)
 - ElevenLabs API key from [elevenlabs.io](https://elevenlabs.io) (for voice)
@@ -114,7 +114,7 @@ cd koromind
 
 # Install with uv (recommended)
 pip install uv
-uv venv -p python3.11
+uv venv -p python3.12
 source .venv/bin/activate
 uv sync
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "koromind"
 version = "2.0.0"
 description = "Multi-interface personal AI assistant with voice and agentic capabilities"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "python-telegram-bot>=20.0,<22.0",
     "elevenlabs>=1.0.0,<2.0.0",
@@ -54,7 +54,7 @@ filterwarnings = [
 
 [tool.black]
 line-length = 88
-target-version = ["py311"]
+target-version = ["py312"]
 
 [tool.isort]
 profile = "black"
@@ -62,7 +62,7 @@ line_length = 88
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py312"
 
 [tool.coverage.run]
 source = ["koro"]


### PR DESCRIPTION
## Summary

- Bump minimum Python version from 3.11 to 3.12
- Required for Pydantic + `typing.TypedDict` compatibility (Pydantic validation of TypedDict requires Python 3.12+)

## Changes

- `pyproject.toml`: Update `requires-python` and `target-version` settings
- `Dockerfile`: Install Python 3.12 from Debian trixie
- `.github/workflows/ci.yml`: Update CI to use Python 3.12
- `.pre-commit-config.yaml`: Update language_version
- Documentation updates (AGENTS.md, README.md, CONTRIBUTING.md, specs)
